### PR TITLE
Add metrics configuration for node and service templates

### DIFF
--- a/chart/templates/node.yaml
+++ b/chart/templates/node.yaml
@@ -106,6 +106,17 @@ spec:
             # which reduces CPU load for non-baking nodes.
             - name: CONCORDIUM_NODE_RUNTIME_HASKELL_RTS_FLAGS
               value: "-N2,-I0"
+
+            {{- if .Values.metrics.port }}
+            - name: CONCORDIUM_NODE_PROMETHEUS_LISTEN_PORT
+              value: {{ .Values.metrics.port | quote }}
+            {{- end }}
+
+            {{- if .Values.persistence.address }}
+            - name: CONCORDIUM_NODE_PROMETHEUS_LISTEN_ADDRESS
+              value: {{ .Values.persistence.address | quote }}
+            {{- end }}
+
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: data

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
     - name: grpc
       protocol: TCP
-      port: {{ .Values.service.port }}
+      port: {{ .Values.service.port }}
       targetPort: 20000
     {{- if .Values.metrics.port }}
     - name: metrics

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -10,5 +10,11 @@ spec:
   ports:
     - name: grpc
       protocol: TCP
-      port: 20000
+      port: {{ .Values.service.port }}
       targetPort: 20000
+    {{- if .Values.metrics.port }}
+    - name: metrics
+      protocol: TCP
+      port: {{ .Values.metrics.port }}
+      targetPort: {{ .Values.metrics.port }}
+    {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -34,6 +34,8 @@ resources:
 service:
   # type is the type of service to create, allowed values are (ClusterIP | NodePort | LoadBalancer)
   type: ClusterIP
+  # port is the port to expose the service on
+  port: 20000
   # nodePort is the port to expose the service on if type is NodePort
   nodePort:
 
@@ -61,3 +63,10 @@ collector:
   nodeName:
   # interval describes how often to collect the statistics from the node, in milliseconds
   interval: 5000
+
+# metrics holds the configuration for the metrics endpoint to expose
+metrics:
+  # port configures the port to run the Prometheus exporter on, it does not run the exporter by default, the port must be set to enable it.
+  port:
+  # address specifies the IP address to listen on, defaults to 127.0.0.1
+  address:


### PR DESCRIPTION
This pull request adds metrics configuration for the node and service templates. It includes changes to the node template to configure the Prometheus exporter port and address, and changes to the service template to expose the metrics port. This allows for monitoring and collecting metrics from the deployed nodes and services.